### PR TITLE
Update `autodrive` package to facilitate open-loop vehicle control

### DIFF
--- a/autodrive/config/planner_params.yaml
+++ b/autodrive/config/planner_params.yaml
@@ -17,16 +17,17 @@ TebLocalPlannerROS:
   feasibility_check_no_poses: 2
   allow_init_backward_motion: false
   # Robot
-  # car length = 0.50   car width = 0.27
-  # wheel base = 0.33   track width = 0.23
-  # front offset = 0.09 rear offset = 0.08
+  # car length = 0.50 m     car width = 0.27 m
+  # wheel base = 0.33 m     track width = 0.23 m
+  # front offset = 0.09 m   rear offset = 0.08 m
+  # max steering angle = 30 deg
   max_vel_x: 0.4 # m/s
   max_vel_x_backwards: 0.2 # m/s
   max_vel_theta: 0.2 # rad/s [angular velocity is also bounded by min_turning_radius in case of a carlike robot (omega = v/r)]
   acc_lim_x: 0.15
   acc_lim_theta: 0.3927
   # Carlike robot parameters
-  min_turning_radius: 0.74 # min turning radius of the carlike robot (compute value using a model or adjust with rqt_reconfigure manually)
+  min_turning_radius: 0.5716 # min turning radius of the carlike robot (compute value using a model or adjust with rqt_reconfigure manually)
   wheelbase: 0.33 # wheelbase of the carlike robot
   cmd_angle_instead_rotvel: True # return steering angle instead of the rotvel (angular.z of twist message)
   footprint_model:

--- a/autodrive/scripts/ol_ctrl.py
+++ b/autodrive/scripts/ol_ctrl.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+'''
+BSD 2-Clause License
+
+Copyright (c) 2022, Tinker Twins
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
+
+################################################################################
+
+import rospy
+from ackermann_msgs.msg import AckermannDriveStamped
+import numpy as np
+
+################################################################################
+
+if __name__=="__main__":
+    
+    rospy.init_node('open_loop_ctrl')
+
+    ol_ctrl_pub = rospy.Publisher('/vesc/low_level/ackermann_cmd_mux/input/teleop', AckermannDriveStamped, queue_size=10)
+    ol_ctrl_msg = AckermannDriveStamped()
+
+    rate = rospy.Rate(20) # Control drequency (Hz)
+
+    try:
+        while not rospy.is_shutdown():
+            # Constant control inputs
+            #lin_vel = 1.0
+            #ang_vel = 0.523599
+            # Constant control inputs with Gaussian noise (sampled from normal distribution)
+            # Reference Example: noise = np.random.normal(0,1) 0 mean and 1 std dev
+            lin_vel = 1.5 + np.random.normal(0,0.1)
+            ang_vel = 0.4 + np.random.normal(0,0.2)
+            ol_ctrl_msg.header.stamp = rospy.Time.now()
+            ol_ctrl_msg.header.frame_id = 'base_link'
+            ol_ctrl_msg.drive.speed = lin_vel
+            ol_ctrl_msg.drive.steering_angle = ang_vel
+            #print("Lin Vel : {:.4} m/s".format(ol_ctrl_msg.drive.speed))
+            #print("Ang Vel : {:.4} rad/s".format(ol_ctrl_msg.drive.steering_angle))
+            ol_ctrl_pub.publish(ol_ctrl_msg)
+            rate.sleep()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
Updated `autodrive` package to facilitate open-loop vehicle control with/without Gaussian noise (sampled from normal distribution).