### PR TITLE
Update `f1tenth` package to facilitate open-loop vehicle control

### DIFF
--- a/f1tenth/racecar/racecar/config/racecar-v2/vesc.yaml
+++ b/f1tenth/racecar/racecar/config/racecar-v2/vesc.yaml
@@ -19,8 +19,8 @@ steering_angle_to_servo_offset: 0.435 # 0.5304
 # publish odom to base link tf
 vesc_to_odom/publish_tf: false
 
-# car wheelbase is about 25cm 
-wheelbase: .25
+# car wheelbase is about 0.33 m 
+wheelbase: 0.33
 
 vesc_driver:
   port: /dev/sensors/vesc

--- a/f1tenth/racecar/racecar/launch/open_loop_ctrl_autodrive.launch
+++ b/f1tenth/racecar/racecar/launch/open_loop_ctrl_autodrive.launch
@@ -1,0 +1,22 @@
+<!-- -*- mode: XML -*- -->
+<launch>
+
+  <!-- F1TENTH VESC -->
+  <arg name="racecar_version" default="racecar-v2" />
+  <arg name="run_camera" default="false"/>
+  <group ns="vesc">
+    <!-- Spawn MUXs -->
+    <include file="$(find racecar)/launch/mux.launch" />
+    <!-- VESC Driver -->
+    <include file="$(find racecar)/launch/includes/$(arg racecar_version)/vesc.launch.xml" >
+      <arg name="racecar_version" value="$(arg racecar_version)" />
+    </include>
+  </group>
+
+  <!-- Static Transforms -->
+  <include file="$(find racecar)/launch/includes/$(arg racecar_version)/static_transforms.launch.xml" />
+
+  <!-- AutoDRIVE-F1TENTH Keyboard Teleop Node -->
+  <node name="teleop_keyboard" pkg="autodrive" type="ol_ctrl.py" output="screen" />
+
+</launch>


### PR DESCRIPTION
Updated `f1tenth` package to include launch files that support open-loop vehicle control with/without Gaussian noise (sampled from normal distribution) using the `autodrive` package.