### PR TITLE
Modify open loop controller to accept command line arguments

### DIFF
--- a/autodrive/scripts/ol_ctrl.py
+++ b/autodrive/scripts/ol_ctrl.py
@@ -40,6 +40,11 @@ if __name__=="__main__":
     
     rospy.init_node('open_loop_ctrl')
 
+    lin_vel = rospy.get_param('/open_loop_ctrl/lin_vel')
+    ang_vel = rospy.get_param('/open_loop_ctrl/ang_vel')
+    lin_noise = rospy.get_param('/open_loop_ctrl/lin_noise')
+    ang_noise = rospy.get_param('/open_loop_ctrl/ang_noise')
+
     ol_ctrl_pub = rospy.Publisher('/vesc/low_level/ackermann_cmd_mux/input/teleop', AckermannDriveStamped, queue_size=10)
     ol_ctrl_msg = AckermannDriveStamped()
 
@@ -52,12 +57,14 @@ if __name__=="__main__":
             #ang_vel = 0.523599
             # Constant control inputs with Gaussian noise (sampled from normal distribution)
             # Reference Example: noise = np.random.normal(0,1) 0 mean and 1 std dev
-            lin_vel = 1.5 + np.random.normal(0,0.1)
-            ang_vel = 0.4 + np.random.normal(0,0.2)
+            #lin_vel = 1.5 + np.random.normal(0,0.1)
+            #ang_vel = 0.4 + np.random.normal(0,0.2)
+            lin_vel_cmd = lin_vel + np.random.normal(0,lin_noise)
+            ang_vel_cmd = ang_vel + np.random.normal(0,ang_noise)
             ol_ctrl_msg.header.stamp = rospy.Time.now()
             ol_ctrl_msg.header.frame_id = 'base_link'
-            ol_ctrl_msg.drive.speed = lin_vel
-            ol_ctrl_msg.drive.steering_angle = ang_vel
+            ol_ctrl_msg.drive.speed = lin_vel_cmd
+            ol_ctrl_msg.drive.steering_angle = ang_vel_cmd
             #print("Lin Vel : {:.4} m/s".format(ol_ctrl_msg.drive.speed))
             #print("Ang Vel : {:.4} rad/s".format(ol_ctrl_msg.drive.steering_angle))
             ol_ctrl_pub.publish(ol_ctrl_msg)

--- a/f1tenth/racecar/racecar/launch/open_loop_ctrl_autodrive.launch
+++ b/f1tenth/racecar/racecar/launch/open_loop_ctrl_autodrive.launch
@@ -17,6 +17,15 @@
   <include file="$(find racecar)/launch/includes/$(arg racecar_version)/static_transforms.launch.xml" />
 
   <!-- AutoDRIVE-F1TENTH Keyboard Teleop Node -->
-  <node name="teleop_keyboard" pkg="autodrive" type="ol_ctrl.py" output="screen" />
+  <arg name="lin_vel" default="0.0" />
+  <arg name="ang_vel" default="0.0" />
+  <arg name="lin_noise" default="0.0" />
+  <arg name="ang_noise" default="0.0" />
+  <node name="open_loop_ctrl" pkg="autodrive" type="ol_ctrl.py" output="screen" clear_params="true" >
+  <param name="lin_vel" value="$(arg lin_vel)" />
+  <param name="ang_vel" value="$(arg ang_vel)" />
+  <param name="lin_noise" value="$(arg lin_noise)" />
+  <param name="ang_noise" value="$(arg ang_noise)" />
+  </node>
 
 </launch>


### PR DESCRIPTION
Modified open loop controller script in `autodrive` package (and corresponding launch file in `racecar` package of `f1tenth`) to accept command line arguments for:
- `lin_vel` Linear velocity in m/s
- `ang_vel` Angular velocity in rad/s
- `lin_noise` Standard deviation of Gaussian noise in linear velocity
- `ang_noise` Standard deviation of Gaussian noise in angular velocity