### PR TITLE
Modify open loop controller to support fishhook test

### DIFF
--- a/autodrive/scripts/ol_ctrl.py
+++ b/autodrive/scripts/ol_ctrl.py
@@ -86,6 +86,7 @@ if __name__=="__main__":
             # Reference Example: noise = np.random.normal(0,1) 0 mean and 1 std dev
             #lin_vel = 1.5 + np.random.normal(0,0.1)
             #ang_vel = 0.4 + np.random.normal(0,0.2)
+            '''
             # Straight
             t_delay = rospy.Duration.from_sec(2.5/lin_vel).to_sec()
             t_start = rospy.Time.now().to_sec()
@@ -99,6 +100,7 @@ if __name__=="__main__":
                 #print("Lin Vel : {:.4} m/s".format(ol_ctrl_msg.drive.speed))
                 #print("Ang Vel : {:.4} rad/s".format(ol_ctrl_msg.drive.steering_angle))
                 ol_ctrl_pub.publish(ol_ctrl_msg)
+            # Slalom
             for i in range(3):
 		    # Left
 		    t_delay = rospy.Duration.from_sec(1.0/lin_vel).to_sec()
@@ -126,6 +128,40 @@ if __name__=="__main__":
 		        #print("Lin Vel : {:.4} m/s".format(ol_ctrl_msg.drive.speed))
 		        #print("Ang Vel : {:.4} rad/s".format(ol_ctrl_msg.drive.steering_angle))
 		        ol_ctrl_pub.publish(ol_ctrl_msg)
+	    # Stop
+	    lin_vel_cmd = 0
+            ang_vel_cmd = 0
+            ol_ctrl_msg.header.stamp = rospy.Time.now()
+            ol_ctrl_msg.header.frame_id = 'base_link'
+            ol_ctrl_msg.drive.speed = lin_vel_cmd
+            ol_ctrl_msg.drive.steering_angle = ang_vel_cmd
+            #print("Lin Vel : {:.4} m/s".format(ol_ctrl_msg.drive.speed))
+            #print("Ang Vel : {:.4} rad/s".format(ol_ctrl_msg.drive.steering_angle))
+            ol_ctrl_pub.publish(ol_ctrl_msg)
+
+            rospy.signal_shutdown('Test completed!')
+            '''
+################################################################################
+            # Fishhook test (constant linear velocity and time-delayed varying steering with Gaussian noise - sampled from normal distribution)
+            # Reference Example: noise = np.random.normal(0,1) 0 mean and 1 std dev
+            #lin_vel = 1.5 + np.random.normal(0,0.1)
+            #ang_vel = 0.4 + np.random.normal(0,0.2)
+            # Fishhook
+            for delta in [0.15,0.175,0.2,0.225,0.25]:
+                print(delta)
+            	turn_rad = 0.33/np.tan(delta)
+	    	t_delay = rospy.Duration.from_sec(2*np.pi*turn_rad/lin_vel).to_sec()
+	    	t_start = rospy.Time.now().to_sec()
+	   	while (rospy.Time.now().to_sec() - t_start) <= t_delay:
+	     	    lin_vel_cmd = lin_vel + np.random.normal(0,lin_noise)
+	    	    ang_vel_cmd = delta
+	     	    ol_ctrl_msg.header.stamp = rospy.Time.now()
+	      	    ol_ctrl_msg.header.frame_id = 'base_link'
+	      	    ol_ctrl_msg.drive.speed = lin_vel_cmd
+	      	    ol_ctrl_msg.drive.steering_angle = ang_vel_cmd
+	      	    #print("Lin Vel : {:.4} m/s".format(ol_ctrl_msg.drive.speed))
+	      	    #print("Ang Vel : {:.4} rad/s".format(ol_ctrl_msg.drive.steering_angle))
+	      	    ol_ctrl_pub.publish(ol_ctrl_msg)
 	    # Stop
 	    lin_vel_cmd = 0
             ang_vel_cmd = 0


### PR DESCRIPTION
Modified open loop controller script in `autodrive` package (and corresponding launch file in `racecar` package of `f1tenth`) to support **fishhook** test while accepting command line arguments for:
- `lin_vel` Linear velocity in m/s
- `lin_noise` Standard deviation of Gaussian noise in linear velocity