### PR TITLE
Update teleop script with limits & step sizes for actuation

### DIFF
--- a/autodrive/scripts/teleop.py
+++ b/autodrive/scripts/teleop.py
@@ -40,10 +40,10 @@ else:
 
 ################################################################################
 
-DRIVE_LIMIT = 5
-STEER_LIMIT = 1
+DRIVE_LIMIT = 5 # 3
+STEER_LIMIT = 0.52
 DRIVE_STEP_SIZE = 1
-STEER_STEP_SIZE = 1
+STEER_STEP_SIZE = 0.52 # 0.13
 
 info = """
 -------------------------------------


### PR DESCRIPTION
Updated `teleop.py` script from `autodrive` package with limits & step sizes for vehicle actuation.

- `drive` command referes to throttle/brake/reverse input to the vehicle
- `steer` command refers to steering input to the vehicle
- `DRIVE_LIMIT` refers to maximum limit on throttle/brake/reverse input to the vehicle
- `STEER_LIMIT` refers to maximum limit on steering input to the vehicle
- `DRIVE_STEP_SIZE` refers to variation in throttle/brake/reverse input to the vehicle upon one press of a key
- `STEER_STEP_SIZE` refers to variation in steering input to the vehicle upon one press of a key

Following parameters were used:

- `DRIVE_LIMIT` = **5** (or **3** for slow, easy - more "controllable" experience)
- `STEER_LIMIT` = **0.52** (0.52 rad is physical steering limit of vehicle, reduce to constrain the vehicle)
- `DRIVE_STEP_SIZE` = **1** (increase/decrease to get coarser/finer throttle/brake/reverse variation)
- `STEER_STEP_SIZE` = **0.52** (or **0.13** for multi-step steering variation)