### PR TITLE
Calibrate and update VESC parameters

### DIFF
--- a/autodrive/scripts/teleop.py
+++ b/autodrive/scripts/teleop.py
@@ -43,7 +43,7 @@ else:
 DRIVE_LIMIT = 5 # 3
 STEER_LIMIT = 0.52
 DRIVE_STEP_SIZE = 1
-STEER_STEP_SIZE = 0.52 # 0.13
+STEER_STEP_SIZE = 0.104 # 0.52
 
 info = """
 -------------------------------------

--- a/f1tenth/racecar/racecar/config/racecar-v2/vesc.yaml
+++ b/f1tenth/racecar/racecar/config/racecar-v2/vesc.yaml
@@ -1,7 +1,7 @@
 
 # erpm (electrical rpm) = speed_to_erpm_gain * speed (meters / second) + speed_to_erpm_offset
-speed_to_erpm_gain: 4614
-speed_to_erpm_offset: 0.0
+speed_to_erpm_gain: 7300 # 4614
+speed_to_erpm_offset: 250 # 0.0
 
 tachometer_ticks_to_meters_gain: 0.00225
 # servo smoother - limits rotation speed and smooths anything above limit
@@ -13,7 +13,7 @@ max_acceleration: 2.5 # meters/second^2
 throttle_smoother_rate: 75.0 # messages/sec
 
 # servo value (0 to 1) =  steering_angle_to_servo_gain * steering angle (radians) + steering_angle_to_servo_offset
-steering_angle_to_servo_gain: -1.2135
+steering_angle_to_servo_gain: -0.6 # -1.2135
 steering_angle_to_servo_offset: 0.435 # 0.5304
 
 # publish odom to base link tf


### PR DESCRIPTION
[Calibrated](https://f1tenth.readthedocs.io/en/foxy_test/getting_started/driving/drive_calib_odom.html) and [updated](https://github.com/ARMLabCUICAR/AutoDRIVE-F1TENTH-ARMLab/commit/30bd1b6c800e9e94807baeaa164bdf6b51288ec5) [`VESC parameters`](https://github.com/Tinker-Twins/AutoDRIVE-F1TENTH-ARMLab/blob/main/f1tenth/racecar/racecar/config/racecar-v2/vesc.yaml) for drive motor and steering servo to comply with real-world metric units for vehicle motion. Following are the updated parameters:

#### Drive motor erpm (electrical rpm) = speed_to_erpm_gain * speed (meters / second) + speed_to_erpm_offset
```
speed_to_erpm_gain: 7300
speed_to_erpm_offset: 250
```

#### Steer servo value (0 to 1) =  steering_angle_to_servo_gain * steering angle (radians) + steering_angle_to_servo_offset
```
steering_angle_to_servo_gain: -0.6
steering_angle_to_servo_offset: 0.435
```